### PR TITLE
Make addable as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
    "license": "UNLICENSED",
    "main": "dist/footer.js",
    "typings": "dist/index.d.ts",
-   "exports": "dist/footer.modern.js",
+   "exports": "./dist/footer.modern.js",
    "module": "dist/footer.module.js",
    "unpkg": "dist/footer.umd.js",
    "files": [

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
       "dist"
    ],
    "scripts": {
-      "build": "microbundle --jsx React.createElement",
+      "prepare": "microbundle --jsx React.createElement",
       "dev": "microbundle watch",
       "storybook": "start-storybook -p 6006 -h localhost",
       "build-storybook": "build-storybook",


### PR DESCRIPTION
We want to be able to add the footer here as a dependency in nextjs-community and ifixit in the future. It's not ideal to keep the tarball around, and publishing it as an npm package will add some extra work to maintain so we plan to add this git repo as a dependency in the other repos' `package.lock`. However there's a couple things preventing that from happening:

1. Export target doesn't start with `./` so an error is thrown at next.js build time
2. The source isn't getting bundled up when we install it as a dependency because there is no `prepare` in `package.lock`

This pull addresses those two issues.

CR should be straight forward

QA
--
I can handle this one. I'm gonna try adding it in nextjs-community with these changes.

Connects https://github.com/ifixit/ifixit/issues/39183